### PR TITLE
fix!: update the bundle yaml with the flavor name as well

### DIFF
--- a/src/test/e2e/02_update-yaml_test.go
+++ b/src/test/e2e/02_update-yaml_test.go
@@ -35,6 +35,6 @@ func TestUpdateYamlCommand(t *testing.T) {
 	err = e2e.LoadYaml("src/test/sandbox/bundle/uds-bundle.yaml", &bundle)
 	require.NoError(t, err)
 
-	require.Equal(t, "1.0.0-uds.0", bundle.Metadata.Version)
-	require.Equal(t, "1.0.0-uds.0", bundle.Packages[0].Ref)
+	require.Equal(t, "1.0.0-uds.0-base", bundle.Metadata.Version)
+	require.Equal(t, "1.0.0-uds.0-base", bundle.Packages[0].Ref)
 }

--- a/src/test/e2e/05_packages_flag_test.go
+++ b/src/test/e2e/05_packages_flag_test.go
@@ -98,8 +98,8 @@ func TestPackageFlagUpdateYaml(t *testing.T) {
 	err = e2e.LoadYaml("src/test/sandbox/bundle/uds-bundle.yaml", &bundle)
 	require.NoError(t, err)
 
-	require.Equal(t, "1.0.0-flag.0", bundle.Metadata.Version)
+	require.Equal(t, "1.0.0-flag.0-base", bundle.Metadata.Version)
 	require.Equal(t, "devel", bundle.Packages[0].Ref)
-	require.Equal(t, "1.0.0-flag.0", bundle.Packages[1].Ref)
+	require.Equal(t, "1.0.0-flag.0-base", bundle.Packages[1].Ref)
 	require.Equal(t, "devel", bundle.Packages[2].Ref)
 }

--- a/src/version/yaml.go
+++ b/src/version/yaml.go
@@ -50,12 +50,14 @@ func updateBundleYaml(flavor types.Flavor, packageName string) error {
 		return err
 	}
 
-	bundle.Metadata.Version = flavor.Version
+	tag := utils.JoinNonEmpty("-", flavor.Version, flavor.Name)
+
+	bundle.Metadata.Version = tag
 
 	// Find the package that matches the package name and update its ref
 	for i, bundledPackage := range bundle.Packages {
 		if bundledPackage.Name == packageName {
-			bundle.Packages[i].Ref = flavor.Version
+			bundle.Packages[i].Ref = tag
 		}
 	}
 
@@ -64,6 +66,6 @@ func updateBundleYaml(flavor types.Flavor, packageName string) error {
 		return err
 	}
 
-	fmt.Printf("Updated uds-bundle.yaml with version %s\n", flavor.Version)
+	fmt.Printf("Updated uds-bundle.yaml with version %s\n", tag)
 	return nil
 }

--- a/src/version/yaml_test.go
+++ b/src/version/yaml_test.go
@@ -1,0 +1,195 @@
+// Copyright 2025 Defense Unicorns
+// SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+
+package version
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	uds "github.com/defenseunicorns/uds-cli/src/types"
+	"github.com/defenseunicorns/uds-pk/src/types"
+	"github.com/defenseunicorns/uds-pk/src/utils"
+	"github.com/stretchr/testify/require"
+	zarf "github.com/zarf-dev/zarf/src/api/v1alpha1"
+)
+
+func TestUpdateZarfYaml(t *testing.T) {
+	tests := []struct {
+		name          string
+		flavor        types.Flavor
+		initialYaml   string
+		expectedName  string
+		expectedError bool
+	}{
+		{
+			name: "basic update",
+			flavor: types.Flavor{
+				Name:    "test",
+				Version: "1.2.3",
+			},
+			initialYaml: `
+metadata:
+  name: test-package
+  version: 1.0.0
+`,
+			expectedName:  "test-package",
+			expectedError: false,
+		},
+		{
+			name: "file doesn't exist",
+			flavor: types.Flavor{
+				Name:    "test",
+				Version: "1.2.3",
+			},
+			initialYaml:   "non-existent",
+			expectedName:  "",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp dir for test
+			tmpDir := t.TempDir()
+			zarfPath := filepath.Join(tmpDir, "zarf.yaml")
+
+			// Write initial YAML if it's not testing for non-existent file
+			if tt.initialYaml != "non-existent" {
+				err := os.WriteFile(zarfPath, []byte(tt.initialYaml), 0644)
+				require.NoError(t, err)
+			}
+
+			// Call the function
+			packageName, err := updateZarfYaml(tt.flavor, tmpDir)
+
+			// Check results
+			if tt.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedName, packageName)
+
+				// Verify the file was updated correctly
+				var zarfPackage zarf.ZarfPackage
+				err = utils.LoadYaml(zarfPath, &zarfPackage)
+				require.NoError(t, err)
+				require.Equal(t, tt.flavor.Version, zarfPackage.Metadata.Version)
+			}
+		})
+	}
+}
+
+func TestUpdateBundleYaml(t *testing.T) {
+	// Save current working directory
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(cwd)
+
+	tests := []struct {
+		name          string
+		flavor        types.Flavor
+		packageName   string
+		initialYaml   string
+		expectedError bool
+	}{
+		{
+			name: "update existing package",
+			flavor: types.Flavor{
+				Name:    "test",
+				Version: "1.2.3",
+			},
+			packageName: "test-package",
+			initialYaml: `
+metadata:
+  name: test-bundle
+  version: 1.0.0
+packages:
+  - name: test-package
+    ref: 1.0.0
+  - name: other-package
+    ref: 2.0.0
+`,
+			expectedError: false,
+		},
+		{
+			name: "package not found",
+			flavor: types.Flavor{
+				Name:    "test",
+				Version: "1.2.3",
+			},
+			packageName: "missing-package",
+			initialYaml: `
+metadata:
+  name: test-bundle
+  version: 1.0.0
+packages:
+  - name: test-package
+    ref: 1.0.0
+`,
+			expectedError: false,
+		},
+		{
+			name: "file doesn't exist",
+			flavor: types.Flavor{
+				Name:    "test",
+				Version: "1.2.3",
+			},
+			packageName:   "test-package",
+			initialYaml:   "non-existent",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp dir for test
+			tmpDir := t.TempDir()
+			bundleDir := filepath.Join(tmpDir, "bundle")
+			err := os.MkdirAll(bundleDir, 0755)
+			require.NoError(t, err)
+			
+			bundlePath := filepath.Join(bundleDir, "uds-bundle.yaml")
+			
+			// Write initial YAML if it's not testing for non-existent file
+			if tt.initialYaml != "non-existent" {
+				err = os.WriteFile(bundlePath, []byte(tt.initialYaml), 0644)
+				require.NoError(t, err)
+			}
+			
+			// Change to temp dir for test
+			err = os.Chdir(tmpDir)
+			require.NoError(t, err)
+
+			// Call the function
+			err = updateBundleYaml(tt.flavor, tt.packageName)
+
+			// Check results
+			if tt.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+
+				// Verify the file was updated correctly
+				var bundle uds.UDSBundle
+				err = utils.LoadYaml("bundle/uds-bundle.yaml", &bundle)
+				require.NoError(t, err)
+				
+				// Check bundle version was updated
+				expectedVersion := tt.flavor.Version
+				if tt.flavor.Name != "" {
+					expectedVersion = tt.flavor.Version + "-" + tt.flavor.Name
+				}
+				require.Equal(t, expectedVersion, bundle.Metadata.Version)
+				
+				// Check if package ref was updated
+				for _, pkg := range bundle.Packages {
+					if pkg.Name == tt.packageName {
+						require.Equal(t, expectedVersion, pkg.Ref)
+					}
+				}
+			}
+		})
+	}
+}

--- a/src/version/yaml_test.go
+++ b/src/version/yaml_test.go
@@ -85,7 +85,12 @@ func TestUpdateBundleYaml(t *testing.T) {
 	// Save current working directory
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
-	defer os.Chdir(cwd)
+	defer func() {
+		err := os.Chdir(cwd)
+		if err != nil {
+			t.Logf("Failed to change back to original directory: %v", err)
+		}
+	}()
 
 	tests := []struct {
 		name          string


### PR DESCRIPTION
> [!CAUTION]
> :warning: **BREAKING CHANGES**
> This updates to better handle Zarf including the flavor in the package name which requires the flavor to now be in the `ref` field of UDS CLI.  If a user is on an older version of Zarf they will need to manually move the package to use this PK version.